### PR TITLE
Render fave cards

### DIFF
--- a/src/components/MovieCard/MovieCard.css
+++ b/src/components/MovieCard/MovieCard.css
@@ -15,7 +15,7 @@
 
 .card__image-favorite {
   height:30px;
-  background-color:rgba(255,255,255,0);
+  background-color:rgba(255,255,255, 0.1);
   position:absolute;
   z-index:1;
   right:4%;
@@ -59,4 +59,16 @@
 @keyframes movie-micro {
   0% { transform: scale(1)}
   100%{transform: scale(1.03)}
+}
+
+.favorite {
+  box-shadow: 0px 0px 15px gold;  
+}
+
+.favorite:hover {
+  box-shadow: 0px 0px 20px gold;
+}
+
+.favorite .card__image-favorite {
+  background-color:rgba(255,255,255, 0);
 }

--- a/src/components/MovieCard/MovieCard.js
+++ b/src/components/MovieCard/MovieCard.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 import './MovieCard.css';
-import star from '../../images/bluestar.svg';
+import star from '../../images/star.svg';
 import favstar from '../../images/fav-star.svg';
 
 export const MovieCard = ({movie, toggleFavorites, favorites}) => {

--- a/src/components/MovieCard/MovieCard.js
+++ b/src/components/MovieCard/MovieCard.js
@@ -1,16 +1,20 @@
 import React from 'react';
-import { Link } from 'react-router-dom'
+import { Link } from 'react-router-dom';
+import { connect } from 'react-redux';
 import './MovieCard.css';
 import star from '../../images/bluestar.svg';
-import favstar from '../../images/fav-star.svg'
+import favstar from '../../images/fav-star.svg';
 
-const MovieCard = ({movie, toggleFavorites}) => {
+export const MovieCard = ({movie, toggleFavorites, favorites}) => {
+  let isFavorite = favorites.map(movie => movie.title).includes(movie.title);
+  let faveImg = isFavorite ? favstar : star;
+  let faveClass = isFavorite ? 'favorite' : '';
   const id = movie.movie_id;
   return (
     <Link to={`/movie/${id}`}>
-      <div className='movie' movie_id={movie.movie_id}>
+      <div className={`movie ${faveClass}`}  movie_id={movie.movie_id}>
         <img alt='star indicating is a movie is favorited or not' 
-        src={star} 
+        src={faveImg} 
         className='card__image-favorite' 
           onClick={ (e) => {
             toggleFavorites(e, movie)
@@ -34,4 +38,8 @@ const MovieCard = ({movie, toggleFavorites}) => {
   )
 }
 
-export default MovieCard;
+export const mapStateToProps = state => ({
+  favorites: state.favorites
+})
+
+export default connect(mapStateToProps)(MovieCard)

--- a/src/images/star.svg
+++ b/src/images/star.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 55.867 55.867" style="enable-background:new 0 0 55.867 55.867;" xml:space="preserve">
+	viewBox="0 0 55.867 55.867" style="enable-background:new 0 0 55.867 55.867;" xml:space="preserve">
 <path d="M11.287,54.548c-0.207,0-0.414-0.064-0.588-0.191c-0.308-0.224-0.462-0.603-0.397-0.978l3.091-18.018L0.302,22.602
 	c-0.272-0.266-0.37-0.663-0.253-1.024c0.118-0.362,0.431-0.626,0.808-0.681l18.09-2.629l8.091-16.393
 	c0.168-0.342,0.516-0.558,0.896-0.558l0,0c0.381,0,0.729,0.216,0.896,0.558l8.09,16.393l18.091,2.629


### PR DESCRIPTION
## What's this PR do?
Toggles the favorite start img on MovieCards and adds a golden box-shadow to favorited movies to distinguish them visually for the user. In order to create the conditional logic, favorites had to be mapped to props via redux.
### Where should the reviewer start?
- [x] Conditional rendering in MovieCard.js
- [x] MovieCard.css last few lines

### How should this be manually tested?
- [x] try toggling some favorites and see what you think

### Screenshots
<img width="1436" alt="Screen Shot 2019-10-26 at 8 12 19 AM" src="https://user-images.githubusercontent.com/49662828/67620848-9bbebf80-f7c8-11e9-9699-b6307a03d658.png">
